### PR TITLE
Add missing digitalRead() parameter description

### DIFF
--- a/Language/Functions/Digital IO/digitalRead.adoc
+++ b/Language/Functions/Digital IO/digitalRead.adoc
@@ -23,7 +23,7 @@ Reads the value from a specified digital pin, either `HIGH` or `LOW`.
 
 [float]
 === Parameters
-
+`pin`: the number of the digital pin you want to read
 
 [float]
 === Returns


### PR DESCRIPTION
The text under digitalRead() parameters was missing. I copied the text from www.arduino.cc/en/Reference/DigitalRead but left off the incorrect (int) part.